### PR TITLE
Translate CLAUDE.md to Japanese

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,60 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+このファイルは、このリポジトリで作業する際のClaude Code（claude.ai/code）向けのガイダンスです。
 
-## Repository purpose
+## リポジトリの目的
 
-This is a Jekyll-based technical documentation site (`各種ドキュメント保存用`) published via GitHub Pages at https://toshi0907.github.io/docs/. There is no application code — the deliverable is the set of Markdown reference pages under `docs/` and the Jekyll configuration/theme that renders them. There are no tests or linters in this repo; "correctness" means the site builds cleanly and pages render as expected.
+これはJekyllベースの技術ドキュメントサイト（`各種ドキュメント保存用`）で、GitHub Pagesにより https://toshi0907.github.io/docs/ で公開されています。アプリケーションコードは存在せず、成果物は `docs/` 配下のMarkdownリファレンスページと、それをレンダリングするJekyllの設定・テーマです。このリポジトリにテストやリンターはなく、「正しさ」とはサイトがエラーなくビルドでき、ページが期待通りにレンダリングされることを意味します。
 
-## Repository layout
+## リポジトリ構成
 
-- `docs/` — the actual Jekyll site root (this is what gets built/served, not the repo root)
-  - `_config.yml` — Jekyll config; `header_pages:` controls the nav bar page order
-  - `Gemfile` — Ruby deps (Jekyll 4.3.0, Minima theme, jekyll-feed, jekyll-sitemap)
-  - `_layouts/`, `_includes/` — custom layouts (`default.html`, `doc.html`, `page.html`) and partials (`head.html`, `header.html`)
-  - `assets/js/search.js`, `assets/css/search.css`, `search.json` — client-side search (fetches `/docs/search.json` built from the collection)
-  - `index.md` — homepage with the manual doc listing (must stay in sync with `_config.yml`'s `header_pages`)
-  - `<topic>.md` (api, git, github, gdb, html, css, javascript, nodejs, python, csharp, regexp, nginx, shellscript, bat, jekyll, linux, termux, vscode, gas, ...) — individual reference docs, one per technology
-- `copilot-instructions.md` (repo root) — Japanese content-writing guidelines for pages under `docs/*.md` (TOC, front matter, tone, Liquid-syntax escaping, etc.); the content-convention rules below are derived from it
-- `.vscode/tasks.json` — VS Code build task that runs the Jekyll build+serve commands below
+- `docs/` — 実際のJekyllサイトのルート（ビルド・サーブされるのはここであり、リポジトリのルートではない）
+  - `_config.yml` — Jekyll設定。`header_pages:` がナビバーのページ順序を制御する
+  - `Gemfile` — Rubyの依存関係（Jekyll 4.3.0、Minimaテーマ、jekyll-feed、jekyll-sitemap）
+  - `_layouts/`, `_includes/` — カスタムレイアウト（`default.html`、`doc.html`、`page.html`）とパーツ（`head.html`、`header.html`）
+  - `assets/js/search.js`, `assets/css/search.css`, `search.json` — クライアントサイド検索（コレクションから生成される `/docs/search.json` を取得する）
+  - `index.md` — 手動のドキュメント一覧を持つホームページ（`_config.yml` の `header_pages` と同期させる必要がある）
+  - `<topic>.md`（api, git, github, gdb, html, css, javascript, nodejs, python, csharp, regexp, nginx, shellscript, bat, jekyll, linux, termux, vscode, gas, ...）— 技術ごとの個別リファレンスドキュメント
+- `copilot-instructions.md`（リポジトリルート）— `docs/*.md` 配下のページ向けの日本語コンテンツ作成ガイドライン（TOC、フロントマター、文体、Liquid構文のエスケープなど）。下記のコンテンツ規約はこのファイルに由来する
+- `.vscode/tasks.json` — 下記のJekyllビルド・サーブコマンドを実行するVS Codeビルドタスク
 
-## Build / serve commands
+## ビルド・サーブコマンド
 
-All Jekyll commands must be run from the `docs/` subdirectory, not the repo root.
+Jekyllコマンドは必ずリポジトリルートではなく `docs/` サブディレクトリから実行してください。
 
 ```bash
 cd docs
 
-# one-time: install bundler for this user, then put it on PATH (needed every new shell session)
+# 初回のみ: このユーザー用にbundlerをインストールし、PATHに追加する（新しいシェルセッションのたびに必要）
 gem install --user-install bundler
 export PATH="$PATH:/home/runner/.local/share/gem/ruby/3.2.0/bin"
 
-# install gems (first run takes ~15-20s; do not cancel, allow >=60s timeout)
+# gemのインストール（初回は15〜20秒程度かかる。キャンセルせず60秒以上のタイムアウトを設定すること）
 bundle install --path ./vendor/bundle
 
-# build the site (normally completes in well under 1s; do not cancel, allow >=30s timeout)
+# サイトのビルド（通常1秒未満で完了する。キャンセルせず30秒以上のタイムアウトを設定すること）
 bundle exec jekyll build
 
-# serve locally with live rebuild, bind to 0.0.0.0 so it's reachable in a container
+# ローカルでライブリロード付きサーブ。コンテナ内から到達できるよう0.0.0.0にバインドする
 bundle exec jekyll serve --host 0.0.0.0 --port 4000
-# site is then available at http://localhost:4000/docs/ (note the /docs/ baseurl)
+# サイトは http://localhost:4000/docs/ で確認できる（baseurlが /docs/ である点に注意）
 ```
 
-There is no test suite or linter — validation is: build succeeds with no errors, then manually check the page in a running `jekyll serve` (TOC renders, code blocks render, links work).
+テストスイートやリンターは存在しません。検証方法は「ビルドがエラーなく成功すること」、そして「`jekyll serve` を起動した状態で手動確認すること（TOCが生成される、コードブロックがレンダリングされる、リンクが機能する）」です。
 
-Known, expected build noise (not failures): Liquid syntax warnings from `github.md` (documenting `${{ ... }}` GitHub Actions syntax) and Sass deprecation warnings from the Minima theme.
+既知の想定内のビルド出力（エラーではない）: `github.md`（`${{ ... }}` というGitHub Actions構文を説明している）に起因するLiquid構文の警告、およびMinimaテーマによるSassの非推奨警告。
 
-## Content conventions (from `copilot-instructions.md`)
+## コンテンツ規約（`copilot-instructions.md` より）
 
-When adding or editing a page under `docs/*.md`:
+`docs/*.md` 配下のページを追加・編集する際は以下に従ってください。
 
-- Every page needs Jekyll front matter: `layout: page` and a `title`.
-- Every page needs a table of contents using Jekyll/kramdown's auto-TOC, placed right after the front matter: `* 目次` followed by `{:toc}`. Do not hand-write a manual list-based TOC — it won't stay in sync with headings.
-- Body text is written in Japanese (polite/丁寧語), with English technical terms glossed inline where useful (e.g. `shebang（シバン）`).
-- When documenting template syntax that collides with Jekyll's Liquid parser (`${{ ... }}` from GitHub Actions, `${VAR}` from Docker Compose, Helm's `{{ .Values }}`, etc.), wrap the code block in `{% raw %} ... {% endraw %}` so Jekyll doesn't try to evaluate it.
-- Adding a new page requires two additional edits to keep navigation consistent: add the filename to `header_pages:` in `docs/_config.yml`, and add a matching link to the list in `docs/index.md` — keep the ordering identical in both places.
-- Each topic page ends with a `## 参考資料` (references) section split into `### 公式ドキュメント` / `### 学習リソース` / `### ツールとライブラリ` (and optionally `### ベストプラクティス・参考文献`). `copilot-instructions.md` itself should not contain reference links — only rules/guidelines belong there.
+- すべてのページにJekyllのフロントマター（`layout: page` と `title`）が必要です。
+- すべてのページにJekyll/kramdownの自動TOC生成機能を使った目次が必要です。フロントマターの直後に `* 目次` と `{:toc}` を配置してください。手動でリスト形式の目次を書いてはいけません（見出しと同期しなくなります）。
+- 本文は日本語（丁寧語）で記述し、必要に応じて英語の専門用語をインラインで併記します（例: `shebang（シバン）`）。
+- GitHub Actionsの `${{ ... }}`、Docker Composeの `${VAR}`、Helmの `{{ .Values }}` など、Jekyllの Liquid パーサーと衝突するテンプレート構文を文書化する場合は、コードブロックを `{% raw %} ... {% endraw %}` で囲み、Jekyllが評価しないようにしてください。
+- 新規ページを追加する場合、ナビゲーションの整合性を保つために2箇所の追加編集が必要です。`docs/_config.yml` の `header_pages:` にファイル名を追加すること、および `docs/index.md` の一覧に対応するリンクを追加すること。両方で並び順を揃えてください。
+- 各技術ページの末尾には `## 参考資料`（参考資料）セクションを配置し、`### 公式ドキュメント` / `### 学習リソース` / `### ツールとライブラリ`（任意で `### ベストプラクティス・参考文献`）に分けます。`copilot-instructions.md` 自体には参考リンクを含めず、ルール・ガイドラインのみを記載します。
 
-## Deployment
+## デプロイ
 
-GitHub Pages builds and deploys automatically from the `docs/` folder on pushes to the main branch (Pages "Deploy from a branch" source) — there is no GitHub Actions workflow in this repo and no manual deploy step.
+GitHub Pagesは、mainブランチへのプッシュ時に `docs/` フォルダから自動的にサイトをビルド・デプロイします（Pagesの「Deploy from a branch」ソース）。このリポジトリにGitHub Actionsワークフローはなく、手動のデプロイ手順もありません。


### PR DESCRIPTION
## Summary
- Translate `CLAUDE.md` (repository/build guidance for Claude Code) from English to Japanese, matching the language used throughout the rest of the repository's documentation

## Test plan
- N/A (documentation-only change, no build/test tooling in this repo)

---
_Generated by [Claude Code](https://claude.ai/code/session_013D6mFVUzfzk7P6k4k3YE1V)_